### PR TITLE
add basic RWD for 992px ~ 1440px

### DIFF
--- a/index.css
+++ b/index.css
@@ -4,7 +4,7 @@ img {
 }
 
 #main {
-  width: 1440px;
+  max-width: 1440px;
   margin: 0 auto;
 }
 
@@ -87,8 +87,7 @@ body {
 }
 
 #content {
-  width: 1019px;
-  float: right;
+  margin-left: 420px;
   background-color: #f3f3f3;
   padding-left: 77px;
   padding-top: 36px;
@@ -142,4 +141,37 @@ body {
 
 a {
   cursor: pointer;
+}
+
+/* Responsive */
+.width-1-3 {
+  float: left;
+  width: 33.3333%;
+}
+
+.clearfix {
+  overflow: auto;
+}
+
+#menu, #content {
+  transition: 150ms margin-left ease;
+}
+
+@media screen and (max-width: 1200px) {
+  #menu {
+    margin-left: 80px;
+  }
+  #content {
+    margin-left: 340px;
+  }
+}
+
+@media screen and (max-width: 992px) {
+  #menu {
+    margin-left: 40px;
+    width: 200px;
+  }
+  #content {
+    margin-left: 260px;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
     <title>
       g0v summit 2016 open design
     </title>
+    <meta charset="utf-8">
     <meta property="og:title" content="g0v零時政府2016 summit設計授權網站"/>
     <meta property="og:image" content="https://g0v.github.io/summit-assets/OG.png"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.3/jquery.min.js">
@@ -223,18 +224,20 @@
             </a>
           </div>
           <center><p>感謝Tuiry提供食物草圖與小人動圖</p></center>
-          <a href="assets/illustration/cutter.gif">
-            <img class="lazy" data-original="assets/illustration/cutter.gif" width="268" height="268">
+          <div class="clearfix">
+          <a href="assets/illustration/cutter.gif" class="width-1-3">
+            <img class="lazy" data-original="assets/illustration/cutter.gif">
             </img>
           </a>
-          <a href="assets/illustration/digger.gif">
-            <img class="lazy" data-original="assets/illustration/digger.gif" width="268" height="268">
+          <a href="assets/illustration/digger.gif" class="width-1-3">
+            <img class="lazy" data-original="assets/illustration/digger.gif">
             </img>
           </a>
-          <a href="assets/illustration/filler.gif">
-            <img class="lazy" data-original="assets/illustration/filler.gif" width="268" height="268">
+          <a href="assets/illustration/filler.gif" class="width-1-3">
+            <img class="lazy" data-original="assets/illustration/filler.gif">
             </img>
           </a>
+          </div>
           <div class="image">
             <a href="assets/illustration/g0v-2016%20summit-main%20visual-2.png">
               <img class="lazy" data-original="assets/illustration/g0v-2016 summit-main visual-2.png" width="862" height="842">


### PR DESCRIPTION
Trying to implement #1, also rewrote some screen-metric-dependent rules. (Still does not work on screen sizes below 992px.)
Also fixed a bug where three images failed to be arranged in a line.
